### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/337a7247-01ee-4057-b098-9b5b6fa9eaa6/23c9d11b-8e73-40bf-b1aa-e2d6ae7391c8/_apis/work/boardbadge/af346373-85a7-482e-87a8-ce7eb5175490)](https://dev.azure.com/aiw-devops/337a7247-01ee-4057-b098-9b5b6fa9eaa6/_boards/board/t/23c9d11b-8e73-40bf-b1aa-e2d6ae7391c8/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2588](https://dev.azure.com/aiw-devops/337a7247-01ee-4057-b098-9b5b6fa9eaa6/_workitems/edit/2588). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.